### PR TITLE
Fix issue where there are parent containers and the offset gets mixed up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bower_components
 node_modules
+*.iml

--- a/paper-audio-player.html
+++ b/paper-audio-player.html
@@ -423,8 +423,8 @@ Custom property                             | Description                       
         var x, r,
             player = this;
 
-        x = e.detail.x - player.offsetLeft - player.$.left.offsetWidth;
-        r = (x / player.$.progress.offsetWidth) * player.duration;
+        x = e.detail.x - player.$.progress.getBoundingClientRect().left;
+        r = (x / player.$.progress.getBoundingClientRect().width) * player.duration;
         player.currentTime = player.$.audio.currentTime = r;
       },
 


### PR DESCRIPTION
Dropping the original version in the middle of a material design lite layout made the audio traversal code not work, as the offsets were different than expected.

Switching to using `getBoundingClientRect()` solved this issue, and helped simplify the code a little.
