### PR TITLE
Suggest using webcomponents-lite.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Then, go ahead and download the player's dependencies:
 1. Import Web Components' polyfill:
 
     ```html
-    <script src="bower_components/webcomponentsjs/webcomponents.js"></script>
+    <script src="bower_components/webcomponentsjs/webcomponents-lite.js"></script>
     ```
 
 2. Import Player element:


### PR DESCRIPTION
Polymer has a light weight shadow dom shim that it ships with called shady DOM. We usually recommend using `webcomponents-lite.js` so you don't have to download the entire shadow dom polyfill (which is massive and slow).
