### PR TITLE
Seperate icons

### DIFF
--- a/paper-audio-icons.html
+++ b/paper-audio-icons.html
@@ -1,0 +1,13 @@
+<link rel="import" href="../iron-icon/iron-icon.html">
+<link rel="import" href="../iron-iconset-svg/iron-iconset-svg.html">
+
+<iron-iconset-svg name="paper-audio-icons" size="24">
+    <svg>
+        <defs>
+            <g id="error-outline"><path d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"/></g>
+            <g id="play-arrow"><path d="M8 5v14l11-7z"/></g>
+            <g id="replay"><path d="M12 5V1L7 6l5 5V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z"/></g>
+            <g id="pause"><path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"/></g>
+        </defs>
+    </svg>
+</iron-iconset-svg>

--- a/paper-audio-player.html
+++ b/paper-audio-player.html
@@ -2,10 +2,11 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../paper-progress/paper-progress.html">
 <link rel="import" href="../iron-icon/iron-icon.html">
-<link rel="import" href="../iron-icons/iron-icons.html">
 <link rel="import" href="../paper-icon-button/paper-icon-button.html">
-<link rel="import" href="../iron-icons/av-icons.html">
 <link rel="import" href="../paper-ripple/paper-ripple.html">
+
+<link rel="import" href="paper-audio-icons.html">
+
 
 <!--
 A custom audio player with material paper style and clean design.
@@ -214,9 +215,9 @@ Custom property                             | Description                       
            on-tap="playPause">
 
         <!-- Icon -->
-        <paper-icon-button id="play" icon="av:play-arrow" class="fit" hidden$="{{ _hidePlayIcon(isPlaying, canBePlayed) }}"></paper-icon-button>
-        <paper-icon-button id="pause" icon="av:pause" class="fit" hidden$="{{ !isPlaying }}"></paper-icon-button>
-        <iron-icon id="error" icon="error-outline" class="fit" hidden$="{{ !error }}"></iron-icon>
+        <paper-icon-button id="play" icon="paper-audio-icons:play-arrow" class="fit" hidden$="{{ _hidePlayIcon(isPlaying, canBePlayed) }}"></paper-icon-button>
+        <paper-icon-button id="pause" icon="paper-audio-icons:pause" class="fit" hidden$="{{ !isPlaying }}"></paper-icon-button>
+        <iron-icon id="error" icon="paper-audio-icons:error-outline" class="fit" hidden$="{{ !error }}"></iron-icon>
       </div>
 
       <div id="center" class="flex" on-down="_onDown">
@@ -247,7 +248,7 @@ Custom property                             | Description                       
         </div>
 
         <!-- Icon -->
-        <paper-icon-button id="replay" class="fit" icon="av:replay"></paper-icon-button>
+        <paper-icon-button id="replay" class="fit" icon="paper-audio-icons:replay"></paper-icon-button>
       </div>
     </div>
   </template>


### PR DESCRIPTION
Seperate icons into custom iconset so the full icon library won't be appended in production systems.

When you use a build script and append imports into a bundled version it's recommended to have a custom iconset with only the icons used by the component.
