### PR TITLE
Added aria support for playing, pausing and jumping using keyboard

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
     "iron-icons": "PolymerElements/iron-icons#~1.0.3",
     "paper-icon-button": "PolymerElements/paper-icon-button#~1.0.5",
     "paper-ripple": "PolymerElements/paper-ripple#~1.0.5",
-    "iron-a11y-keys": "PolymerElements/iron-a11y-keys#~1.0.5"
+    "iron-a11y-keys-behavior": "PolymerElements/iron-a11y-keys-behavior#~1.1.7"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",

--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,8 @@
     "paper-progress": "PolymerElements/paper-progress#~1.0.1",
     "iron-icons": "PolymerElements/iron-icons#~1.0.3",
     "paper-icon-button": "PolymerElements/paper-icon-button#~1.0.5",
-    "paper-ripple": "PolymerElements/paper-ripple#~1.0.5"
+    "paper-ripple": "PolymerElements/paper-ripple#~1.0.5",
+    "iron-a11y-keys": "PolymerElements/iron-a11y-keys#~1.0.5"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",

--- a/paper-audio-player.html
+++ b/paper-audio-player.html
@@ -6,6 +6,7 @@
 <link rel="import" href="../paper-icon-button/paper-icon-button.html">
 <link rel="import" href="../iron-icons/av-icons.html">
 <link rel="import" href="../paper-ripple/paper-ripple.html">
+<link rel="import" href="../iron-a11y-keys/iron-a11y-keys.html">
 
 <!--
 A custom audio player with material paper style and clean design.
@@ -206,6 +207,8 @@ Custom property                             | Description                       
         align-self: flex-end;
       }
     </style>
+
+    <iron-a11y-keys id="a11y" target="[[target]]" keys="p" on-keys-pressed="playPause"></iron-a11y-keys>
 
     <div id="wrapper" class="layout-horizontal">
 

--- a/paper-audio-player.html
+++ b/paper-audio-player.html
@@ -6,7 +6,7 @@
 <link rel="import" href="../paper-icon-button/paper-icon-button.html">
 <link rel="import" href="../iron-icons/av-icons.html">
 <link rel="import" href="../paper-ripple/paper-ripple.html">
-<link rel="import" href="../iron-a11y-keys/iron-a11y-keys.html">
+<link rel="import" href="../iron-a11y-keys-behavior/iron-a11y-keys-behavior.html">
 
 <!--
 A custom audio player with material paper style and clean design.
@@ -208,8 +208,6 @@ Custom property                             | Description                       
       }
     </style>
 
-    <iron-a11y-keys id="a11y" target="[[target]]" keys="p" on-keys-pressed="playPause"></iron-a11y-keys>
-
     <div id="wrapper" class="layout-horizontal">
 
       <div id="left"
@@ -258,6 +256,16 @@ Custom property                             | Description                       
   <script>
     Polymer({
       is: 'paper-audio-player',
+
+      //
+      // Component behaviors
+      behaviors: [Polymer.IronA11yKeysBehavior],
+
+      //
+      // Define component default attributes
+      hostAttributes: {
+        tabindex: 0
+      },
 
       //
       // Define public properties
@@ -313,6 +321,14 @@ Custom property                             | Description                       
         'audio.error'           : '_onError'
       },
 
+      keyBindings: {
+        'space': 'playPause',
+        'enter': 'playPause',
+        'left': '_reverseSmall',
+        'right': '_skipSmall',
+        'down': '_reverseLarge',
+        'up': '_skipLarge'
+      },
 
       //
       // When element is created
@@ -353,6 +369,45 @@ Custom property                             | Description                       
         }
       },
 
+      // Move the play position back a small distance
+      _reverseSmall: function(e) {
+        var player = this;
+        var newTime = 0;
+        if(player.currentTime - player.smallSkip > 0) {
+          newTime = player.currentTime - player.smallSkip;
+        }
+        player._updatePlayPosition(newTime);
+      },
+
+      // Move the play position back a large distance
+      _reverseLarge: function(e) {
+        var player = this;
+        var newTime = 0;
+        if(player.currentTime - player.largeSkip > 0) {
+          newTime = player.currentTime - player.largeSkip;
+        }
+        player._updatePlayPosition(newTime);
+      },
+
+      // Move the play position forward a small distance
+      _skipSmall: function(e) {
+        var player = this;
+        var newTime = player.currentTime + player.timeLeft;
+        if(player.smallSkip < player.timeLeft) {
+          newTime = player.currentTime + player.smallSkip;
+        }
+        player._updatePlayPosition(newTime);
+      },
+
+      // Move the play position forward a large distance
+      _skipLarge: function(e) {
+        var player = this;
+        var newTime = player.currentTime + player.timeLeft;
+        if(player.largeSkip < player.timeLeft) {
+          newTime = player.currentTime + player.largeSkip;
+        }
+        player._updatePlayPosition(newTime);
+      },
 
       // Restart
 

--- a/paper-audio-player.html
+++ b/paper-audio-player.html
@@ -377,6 +377,7 @@ Custom property                             | Description                       
           newTime = player.currentTime - player.smallSkip;
         }
         player._updatePlayPosition(newTime);
+        if (!player.isPlaying) player.$.audio.play();
       },
 
       // Move the play position back a large distance
@@ -387,6 +388,7 @@ Custom property                             | Description                       
           newTime = player.currentTime - player.largeSkip;
         }
         player._updatePlayPosition(newTime);
+        if (!player.isPlaying) player.$.audio.play();
       },
 
       // Move the play position forward a small distance
@@ -397,6 +399,7 @@ Custom property                             | Description                       
           newTime = player.currentTime + player.smallSkip;
         }
         player._updatePlayPosition(newTime);
+        if (!player.isPlaying) player.$.audio.play();
       },
 
       // Move the play position forward a large distance
@@ -407,6 +410,7 @@ Custom property                             | Description                       
           newTime = player.currentTime + player.largeSkip;
         }
         player._updatePlayPosition(newTime);
+        if (!player.isPlaying) player.$.audio.play();
       },
 
       // Restart
@@ -546,13 +550,22 @@ Custom property                             | Description                       
         var x = e.detail.x - player.$.center.getBoundingClientRect().left;
         var r = (x / player.$.center.getBoundingClientRect().width) * player.$.audio.duration;
 
-        player.currentTime = player.$.audio.currentTime = r;
-
-        var percentagePlayed = player.currentTime / player.$.audio.duration;
-        player.$.progress.style.transform = 'scaleX(' + percentagePlayed + ')';
+        this._updatePlayPosition(r);
 
         player.$.progress2.style.width = x + 'px';
       },
+
+      //
+      // Helper function
+      // updates the progress bar based on a time variable
+      _updatePlayPosition: function(newTime) {
+        var player = this;
+        player.currentTime = player.$.audio.currentTime = newTime;
+
+        var percentagePlayed = player.currentTime / player.$.audio.duration;
+        player.$.progress.style.transform = 'scaleX(' + percentagePlayed + ')';
+      },
+
 
       //
       // If src is changed when track is playing,

--- a/paper-audio-player.html
+++ b/paper-audio-player.html
@@ -300,6 +300,14 @@ Custom property                             | Description                       
           type: Number,
           value: 0
         },
+        smallSkip: {
+          type: Number,
+          value: 15
+        },
+        largeSkip: {
+          type: Number,
+          value: 60
+        },
         error: {
           type: Boolean
         },


### PR DESCRIPTION
Saw a mention about adding key controls for the playback to increase accessibility.
https://github.com/gorork/paper-audio-player/issues/14

I'm writing an app where accessibility is important and after reading the guidelines the most important when sound is involved is that you can start playing and stop playing using the keyboard.

In this pull request I add a simple key command to pause and play using the `p` key. Earlier you could start and restart playback using both space and enter. 

But these keys seem to have special syntax in some browsers so I chose a different key so we enable both pausing and starting the audio.

When I tried with space and enter both the playPause function and restart function got triggered for the key events in chrome, which made it impossible to stop the sound using keyboard.
